### PR TITLE
Exponential backoff

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,68 @@
+package deferred
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+const (
+	maxDelay = 1000 * time.Second
+	factor   = 1.6
+	maxInt64 = float64(math.MaxInt64 - 512)
+)
+
+// Strategy defines the algorithm for backoff
+type Strategy interface {
+	Backoff() time.Duration
+	Reset()
+}
+
+type retry struct {
+	delay time.Duration
+}
+
+func (r retry) Backoff() time.Duration {
+	return r.delay
+}
+
+func (r retry) Reset() {}
+
+type exponential struct {
+	initDelay time.Duration
+	retryNum  float64
+}
+
+func (ex *exponential) Backoff() time.Duration {
+	min := ex.initDelay
+	if min <= 0 {
+		min = 100 * time.Millisecond
+	}
+
+	if min >= maxDelay {
+		return maxDelay
+	}
+
+	//calculate this duration
+	minf := float64(min)
+	durf := minf * math.Pow(factor, ex.retryNum)
+	ex.retryNum++
+	durf = rand.Float64()*(durf-minf) + minf
+	//ensure float64 wont overflow int64
+	if durf > maxInt64 {
+		return maxDelay
+	}
+	dur := time.Duration(durf)
+	//keep within bounds
+	if dur < min {
+		return min
+	}
+	if dur > maxDelay {
+		return maxDelay
+	}
+	return dur
+}
+
+func (ex *exponential) Reset() {
+	ex.retryNum = 0
+}

--- a/handler.go
+++ b/handler.go
@@ -34,17 +34,18 @@ var (
 )
 
 type options struct {
-	notify                   func(error)
-	failedHandler            http.Handler
-	timeoutAfter, retryAfter time.Duration
+	notify        func(error)
+	failedHandler http.Handler
+	timeoutAfter  time.Duration
+	Strategy
 }
 
 func newOptions(configs ...Config) options {
 	o := options{
 		notify:        DefaultNotify,
 		failedHandler: DefaultFailedHandler,
-		retryAfter:    DefaultRetryAfter,
 		timeoutAfter:  DefaultTimeoutAfter,
+		Strategy:      retry{DefaultRetryAfter},
 	}
 	for _, c := range configs {
 		o = c(o)
@@ -60,7 +61,16 @@ type Config func(options) options
 // is used as the interval for retrying handler creation
 func WithRetryAfter(d time.Duration) Config {
 	return func(o options) options {
-		o.retryAfter = d
+		o.Strategy = retry{d}
+		return o
+	}
+}
+
+// WithExponentialBackoff returns a Config that will ensure the given duration
+// is used for retrying handler creation with exponential delay
+func WithExponentialBackoff(d time.Duration) Config {
+	return func(o options) options {
+		o.Strategy = &exponential{initDelay: d}
 		return o
 	}
 }
@@ -137,13 +147,14 @@ func NewHandler(ctx context.Context, create func() (http.Handler, error), config
 	go func() {
 		schedule := time.NewTimer(0)
 		defer schedule.Stop()
+		defer opts.Reset()
 		for {
 			select {
 			case <-ctx.Done():
 				resolve(opts.failedHandler)
 				return
 			case <-schedule.C:
-				schedule.Reset(opts.retryAfter)
+				schedule.Reset(opts.Backoff())
 				next, err := create()
 				if err == nil {
 					resolve(next)


### PR DESCRIPTION
This PR adds `WithExponentialBackoff ` for retrying the handler creation. 
`WithRetryAfter` is left to not break API compatibility.
Referred to #1 